### PR TITLE
Localization: add missing Russian (RUS) translations

### DIFF
--- a/GameText.yaml
+++ b/GameText.yaml
@@ -209,6 +209,7 @@ TheImperialBankBuildingIncreases:
 TaxRevenues:
  Id: 429
  ENG: "+2 income per turn, +0.5 Credits Per Colonist"
+ RUS: "+2 дохода за ход, +0.5 кредита на колониста"
 ImperialOffices:
  Id: 430
  ENG: "Imperial Offices"
@@ -342,9 +343,11 @@ CA_Tech_BattleRaiders_Desc:
 CA_Tech_Force_Fields_I_Name:
  Id: 526
  ENG: "Force Fields I"
+ RUS: "Силовые поля I"
 CA_Tech_Force_Fields_I_Desc:
  Id: 527
  ENG: "We can create Force Field Emitters, which have very large radius of protection around our ships." 
+ RUS: "Мы можем создавать излучатели силового поля, которые обеспечивают очень большой радиус защиты вокруг наших кораблей."
 CA_Tech_ECM_MissileDodgeChangeBonus_Bonus:
  Id: 549
  ENG: "Grants missile weapon (such as rockets, guided missiles, and torpedoes) a 16% chance to dodge intercepting fire."
@@ -413,6 +416,7 @@ CA_Tech_MagneticArtillery_Name:
 CA_Tech_MagneticArtillery_Desc:
  Id: 607
  ENG: "Firing weapons using powder charges alone is inefficient. By adding a magnetic push to our projectiles we can put more ordnance on target in a more efficient manner."
+ RUS: "Стрельба из орудий с использованием одних только пороховых зарядов неэффективна. Добавив магнитный ускоритель к нашим снарядам, мы сможем доставлять больше боеприпасов к цели более эффективным способом."
 CA_Tech_MissileArmor_Weapon_HP_Bonus:
  Id: 617
  ENG: "Increases the hitpoints of missile-based weaponry by 25%."
@@ -436,6 +440,7 @@ CA_Tech_PlasmaThrowers_Desc:
 CA_Tech_SiphonBeam_Name:
  Id: 656
  ENG: "Siphon Beam"
+ RUS: "Энерго-сифонный луч"
 CA_Tech_SiphonBeam_Desc:
  Id: 657
  ENG: "Siphon beams create a connection between the firing ship and the target ship's energy shields. The beam depletes the shield energy and transfers is into the firing ship's power stores. It's highly effective against shields."
@@ -489,9 +494,11 @@ FuelCellsCaptureAndStore:
 CA_Module_LightForceField_Name:
  Id: 916
  ENG: "Light Force Field"
+ RUS: "Легкое силовое поле"
 CA_Module_LightForceField_Desc:
  Id: 917
  ENG: "The Light Force Field generates a good coverage and regenerate very fast, when not in combat. It also has some plasma and kinetic resistance."
+ RUS: "Легкое силовое поле обеспечивает хорошее покрытие и очень быстро восстанавливается вне боя. Оно также обладает некоторым сопротивлением к плазме и кинетическому урону."
 CombatInformationCenter:
  Id: 920
  ENG: "Combat Information Center"
@@ -580,6 +587,7 @@ MissileLauncher:
 ThisLongRangeAntishipMissile:
  Id: 995
  ENG: "This long range anti-ship missile is bulky and slow, but can make short work of ships with poor point defense systems."
+ RUS: "Эта противокорабельная ракета дальнего действия громоздкая и медленная, но способна быстро расправиться с кораблями, плохо оснащенными средствами точечной обороны."
 DualMissileTurret:
  Id: 996
  ENG: "MRM Mk2"
@@ -792,9 +800,11 @@ ThisShieldProvidesHpWorth:
 EnergyShield_Name:
  Id: 1050
  ENG: "Energy Shield" 
+ RUS: "Энергетический щит"
 EnergyShield_Desc:
  Id: 1051
  ENG: "A medium sized shield with higher output, which can be installed on larger hulls. It recharges in combat and have larger covreage radius."
+ RUS: "Щит среднего размера с повышенной мощностью, который можно устанавливать на более крупные корпуса. Он перезаряжается в бою и имеет больший радиус покрытия."
 PdVulcanCannon:
  Id: 1074
  ENG: "PD Vulcan Cannon"
@@ -868,42 +878,55 @@ ResearchPerTurn3:
 CA_GoldVein:
  Id: 4387
  ENG: "Gold Vein"
+ RUS: "Золотая жила"
 CA_GoldVeinDesc:
  Id: 4388
  ENG: "Easily extractable gold vein that was exposed in the aftermath of volcanic activity"
+ RUS: "Легкодоступная золотая жила, обнажившаяся в результате вулканической активности"
 CA_GoldVeinDescShort:
  Id: 4389
  ENG: "Provides 2 production per colonist, +3 credits, total worth of 350 production" 
+ RUS: "Дает 2 промышленности на колониста, +3 кредита, общая ценность 350 промышленности"
 CA_MiningSpeedTech:
  Id: 4924
  ENG: "Mining Ships Speed"
+ RUS: "Скорость добывающих кораблей"
 CA_MiningSpeedTechDescr:
  Id: 4925
  ENG: "Increase our Mining Ships mining speed"
+ RUS: "Увеличивает скорость добычи наших добывающих кораблей"
 CA_MiningSpeedTechDescrBonus:
  Id: 4926
  ENG: "20% Empire-wide increase in mining speeds" 
+ RUS: "+20% к скорости добычи по всей империи"
 CA_RefiningEfficiencyTech:
  Id: 4927
  ENG: "Refining Efficiency"
+ RUS: "Эффективность переработки"
 CA_RefiningEfficiencyTechDescr:
  Id: 4928
  ENG: "Increase our Exotic Resources Refining Efficiency"
+ RUS: "Увеличивает эффективность переработки экзотических ресурсов"
 CA_RefiningEfficiencyTechDescrBonus:
  Id: 4929
  ENG: "20% Empire-wide increase in Refining Efficiency"  
+ RUS: "+20% к эффективности переработки по всей империи"
 CA_ExoticStorageTech:
  Id: 4930
  ENG: "Exotic Storage"
+ RUS: "Хранение экзотики"
 CA_ExoticStorageTechDescr:
  Id: 4931
  ENG: "Increase our empire storage capacity for each exotic resource"
+ RUS: "Увеличивает имперскую вместимость хранилищ для каждого экзотического ресурса"
 CA_ExoticStorageTechDescrBonus:
  Id: 4932
  ENG: "20% Empire-wide increase in Exotic Storage"  
+ RUS: "+20% к хранению экзотики по всей империи"
 CA_Tech_BuilderShipEfficiency:
  Id: 4961
  ENG: "Better construction tools alow Builder ships to increase its build rate by 25%"   
+ RUS: "Улучшенные строительные инструменты позволяют строительным кораблям увеличить скорость постройки на 25%"
 TreesWhoNeedsTreesWhat:
  Id: 5082
  ENG: "Your Homeworld is abundant with resources. +0.5 Homeworld Richness."
@@ -1056,9 +1079,11 @@ CA_MaximumGoodsStorage2:
 CA_Module_Beam_PD_Name:
  Id: 5249
  ENG: "Beam Point Defense"
+ RUS: "Лучевая система ПВО"
 CA_Module_Beam_PD_Desc:
  Id: 5250
  ENG: "Beam point defense system can intercept incomming missiles using short pulse beams. It has wide effecting coverage, but small range."
+ RUS: "Система лучевой ПВО может перехватывать приближающиеся ракеты, используя короткие импульсные лучи. Она охватывает большую зону, но имеет маленький радиус действия."
 CA_HeavyAntimatterCannon:
  Id: 5251
  ENG: "Heavy Anti-Matter Cannon"
@@ -1226,6 +1251,7 @@ CA_ShadowStorm:
 CA_ARapidFireShortRange:
  Id: 5292
  ENG: "A rapid fire, short range burst missile platform. Especially deadly against smaller fast moving ships, it functions most practically as an anti fighter/corvette weapon. It features a wide targeting angle, slight chance to penetrate enemy shields and features high explosion radius. It is less efficient vs. Armor."
+ RUS: "Платформа залпового ракетного огня с быстрой стрельбой на короткой дистанции. Особенно смертоносна против небольших быстро движущихся кораблей, наиболее эффективно используется как оружие против истребителей/корветов. Имеет широкий угол наведения, небольшую вероятность пробития вражеских щитов и обладает большим радиусом взрыва. Менее эффективна против брони."
 CA_ShadowStorm2:
  Id: 5293
  ENG: "Shadow Storm"
@@ -1245,6 +1271,7 @@ CA_APlasmaProjectorUsesA:
 CA_Tech_PlasmaWeaponsII_Name:
  Id: 5297
  ENG: "Plasma Weapons II"
+ RUS: "Плазменное оружие II"
 CA_Tech_PlasmaWeaponsII_Desc:
  Id: 5298
  ENG: "We are now able to build heavier plasma weapons by using the previous ionized reactor Plasma and pushing it to new limits with higher pressure. The magnetized pressure system requires, however, more constant power and even extra reactor power to fire."
@@ -2764,9 +2791,11 @@ CA_AColdFusionReactorVery:
 CA_ArmoredColdFusionReactor:
  Id: 8059
  ENG: "Large Fusion Reactor"
+ RUS: "Большой термоядерный реактор"
 CA_BySacrificingASmallAmount:
  Id: 8060
  ENG: "Larger and more efficient Cold Fusion Reactor"
+ RUS: "Более крупный и эффективный термоядерный реактор"
 CA_ArmoredAntimatterReactor:
  Id: 8061
  ENG: "Armored Anti-Matter Reactor"
@@ -2842,6 +2871,7 @@ CA_ARoboticFactoryAGreat:
 CA_FertilityOnBuildFlatProduction:
  Id: 8079
  ENG: " (-0.5) Fertility On Build, +6 flat production per turn, +1 food per turn, +15% tax, +100 storage, +1 Infrastructure, adds ship repair"
+ RUS: " (-0.5) к плодородию при постройке, +6 к продукции за ход, +1 к еде за ход, +15% к налогам, +100 к хранилищу, +1 к инфраструктуре, добавляет ремонт кораблей"
 CA_Tech_NanoMining_Name:
  Id: 8080
  ENG: "Nano Mining"
@@ -3761,6 +3791,7 @@ CA_FlatResearchResearchAndCredits:
 CA_ProductionPerRichness:
  Id: 10078
  ENG: "+2 production per richness, plis 30,000 sensor range"
+ RUS: "+2 промышленности за богатство, плюс 30 000 дальности сенсоров"
 CA_FertilityOnBuild:
  Id: 10079
  ENG: " (+0.3) fertility on build"
@@ -4020,6 +4051,7 @@ CA_SolarPanelsHarvestEnergyFrom:
 CA_ClassIMagshield:
  Id: 12007
  ENG: "Magnetic Shield"
+ RUS: "Магнитный щит"
 CA_WhilstOnlyCapableOfWithstanding:
  Id: 12008
  ENG: "First attampt at energy shielding, the Magnetic Shield is a crude device. Able to withstand only a few hits, it does feature recharge during combat."
@@ -4059,9 +4091,11 @@ CA_ThisExternalEngineChannelsEnergy:
 CA_StaticBarrier:
  Id: 12021
  ENG: "Basic Deflector Shield"
+ RUS: "Базовый дефлекторный щит"
 CA_PlacedOnTheOutsideOf:
  Id: 12022
  ENG: "The Basic Deflector Shield has low strength, but high deflection rate, able to deflect low powered projectiles and it has some resistance to beam weapons. Unfortunately, it has low coverage and slow recharge rate."
+ RUS: "Базовый дефлекторный щит имеет низкую прочность, но высокую вероятность отклонения, способен отражать маломощные снаряды и обладает некоторой устойчивостью к лучевому оружию. К сожалению, радиус покрытия мал, а перезарядка медленная."
 CA_JumpDrive:
  Id: 12023
  ENG: "Jump Drive"
@@ -4093,9 +4127,11 @@ CA_Tech_ArmHeavyShield_Name:
 CA_Module_Medium_Force_Field_Desc:
  Id: 13000
  ENG: "This is a better armored and more powerful Force Field. Its power draw is exceptionally high."
+ RUS: "Это более бронированное и мощное силовое поле. Потребление энергии у него исключительно высокое."
 CA_Tech_Force_Fields_II_Name:
  Id: 13001
  ENG: "Force Fields II"
+ RUS: "Силовые поля II"
 CA_Gunboat:
  Id: 17402
  ENG: "Gunboat"
@@ -4283,6 +4319,7 @@ CA_SinceFightersOfferLimitedSpace:
 CA_Tech_ArmoredColdFusion_Desc:
  Id: 17448
  ENG: "We are able to develop our Cold Fusion Tech into larger, more efficient Reactors. We are also able to upgrade our dedicated power cell's storage due to this advancement."
+ RUS: "Мы способны развить нашу технологию холодного синтеза до более крупных и эффективных реакторов. Благодаря этому достижению мы также можем улучшить вместимость наших специализированных энергоячеек."
 CA_Tech_ArmoredAnti-Matter_Desc:
  Id: 17449
  ENG: "We are able to envelop our Anti-Matter Reactors with decent armor, while still occupying the same space as a normal Plasma Reactor. We are also able to upgrade our dedicated power cell's storage due to this advancement."
@@ -4294,9 +4331,11 @@ CA_Tech_FusionReactor_Desc:
 CA_Tech_ArmHeavyShield_Desc:
  Id: 17451
  ENG: "It is now possible to improve our Class III shields' output and add more protection around them. as well as some projectile deflection."
+ RUS: "Теперь возможно повысить выходную мощность наших щитов класса III и добавить вокруг них дополнительную защиту, а также частичное отклонение снарядов."
 CA_Tech_Force_Fields_II_Desc:
  Id: 17452
  ENG: "We can create larger and more efficient Force Field Emitters."
+ RUS: "Мы можем создавать более крупные и эффективные излучатели силового поля."
 CA_FighterTorpedoes:
  Id: 17453
  ENG: "Fighter Torpedoes"
@@ -4804,27 +4843,35 @@ CA_EnemyCommandersWillQuakeIn:
 CA_Tech_Deflectors_I_Name:
  Id: 17579
  ENG: "Deflectors I"
+ RUS: "Дефлекторы I"
 CA_Tech_Deflectors_I_Desc:
  Id: 17580
  ENG: "Expending our knowledge of basic deflector technology, we can create specialized low yield deflection emitters which have increased deflection rate."
+ RUS: "Расширяя наши знания о базовой технологии дефлекторов, мы можем создавать специализированные маломощные излучатели отражения с повышенной скоростью отражения."
 CA_Tech_Deflectors_II_Name:
  Id: 17581
  ENG: "Deflectors II"
+ RUS: "Дефлекторы II"
 CA_Tech_Deflectors_II_Desc:
  Id: 17582
  ENG: "Increase in hull sizes will require better deflector technology. We can great larger Deflectors and advanced small crafts Deflectors."
+ RUS: "Увеличение размеров корпусов потребует более совершенной технологии дефлекторов. Мы можем создавать более крупные дефлекторы и продвинутые дефлекторы для малых судов."
 CA_Module_Class_I_Deflector_Name:
  Id: 17583
  ENG: "Class I Deflector"
+ RUS: "Дефлектор I класса"
 CA_Module_Class_I_Deflector_Desc:
  Id: 17584
  ENG: "The Class I deflector has a low coverage radius, but better deflection than the Basic Deflector Shield, along with beam resistence."
+ RUS: "Дефлектор I класса имеет малый радиус покрытия, но лучшее отражение, чем базовый дефлекторный щит, а также сопротивление лучевому оружию."
 CA_Module_Class_II_Deflector_Name:
  Id: 17585
  ENG: "Class II Deflector"
+ RUS: "Дефлектор II класса"
 CA_Module_Class_II_Deflector_Desc:
  Id: 17586
  ENG: "A larger deflector with more coverage and better deflection."
+ RUS: "Более крупный дефлектор с большим покрытием и лучшим отражением."
 CA_Tech_Battle_Shielding_I_Name:
  Id: 17587
  ENG: "Battle Shielding I"
@@ -4848,6 +4895,7 @@ CA_Module_Class_I_BattleShield_Name:
 CA_Module_Class_I_BattleShield_Desc:
  Id: 17592
  ENG: "This shield has better power output and combat recharge range. It also has slight projectile deflection."
+ RUS: "Этот щит обладает лучшей мощностью и дальностью перезарядки в бою. Он также имеет небольшое отражение снарядов."
 CA_Module_Class_II_BattleShield_Name:
  Id: 17593
  ENG: "Class II Battle Shield"
@@ -4855,6 +4903,7 @@ CA_Module_Class_II_BattleShield_Name:
 CA_Module_Class_II_BattleShield_Desc:
  Id: 17594
  ENG: "This shield is bigger and heavier, but can produce stonger and larger shield, with some Shield Deflection."
+ RUS: "Этот щит больше и тяжелее, но может создавать более прочный и крупный купол, с некоторым отклонением атак."
 CA_Tech_SmallStations_Desc:
  Id: 17596
  ENG: "In order to defend our colonies from the growing danger of enemy fleets, we have recently devised blueprints to construct our first orbital station, a new type of structure that is larger than our small and heavy platforms."
@@ -5006,6 +5055,7 @@ CA_TheseAreTrulyHighFire:
 CA_MaximumGoodsStorage4:
  Id: 17633
  ENG: "+600 maximum goods storage, +1 infrastructure"
+ RUS: "+600 к максимальному хранению товаров, +1 к инфраструктуре"
 CA_AdvancedPulseCapacitor:
  Id: 17634
  ENG: "Advanced Pulse Capacitor"
@@ -5461,9 +5511,11 @@ CA_ThisCockpitAllowsForTwo:
 CA_Module_SmallCraftForceField_Name:
  Id: 17750
  ENG: "Small Craft Force Field"
+ RUS: "Силовое поле малых судов"
 CA_Module_SmallCraftForceField_Desc:
  Id: 17751
  ENG: "A smaller version of the Light Force Field which can be fitted on small craft. It has good coverage and regeneartion."
+ RUS: "Уменьшенная версия лёгкого силового поля, которую можно установить на малые корабли. Обеспечивает хорошее покрытие и быстрое восстановление."
 CA_DroneAntifighterCannonMk:
  Id: 17752
  ENG: "Drone Anti-Fighter Cannon Mk1"
@@ -5515,9 +5567,11 @@ CA_WithTheAbilityToRecharge:
 CA_FighterBattleShield:
  Id: 17764
  ENG: "Small Craft Battle Shield"
+ RUS: "Боевой щит малого корабля"
 CA_ThisIsAnImprovedVersion2:
  Id: 17765
  ENG: "A Battle shield suitable for Frigates, Corvettes and Fighters. It has higher output and recharge than the older Fighter Shield."
+ RUS: "Боевой щит, подходящий для фрегатов, корветов и истребителей. Обладает большей мощностью и скоростью перезарядки по сравнению со старым щитом истребителя."
 CA_FighterBlueShield:
  Id: 17766
  ENG: "Fighter Blue Shield"
@@ -5529,9 +5583,11 @@ CA_ThisFighterShieldVersionIs:
 CA_AdvancedFighterBattleShield:
  Id: 17768
  ENG: "Adv. Small Craft Battle Shield"
+ RUS: "Продв. боевой щит малого корабля"
 CA_ThisIsAnImprovedVersion3:
  Id: 17769
  ENG: "This is an improved version of the Small Craft Battle Shield. it is less cost effective, but can fit in tight places."
+ RUS: "Улучшенная версия боевого щита малого корабля: менее экономична, но помещается в тесных отсеках."
 CA_AdvancedFighterBlueShield:
  Id: 17770
  ENG: "Advanced Fighter Blue Shield"
@@ -5875,15 +5931,19 @@ CA_Tech_ArmHeavyShield2_Desc:
 CA_Module_Heavy_Force_Field_Name:
  Id: 17855
  ENG: "Heavy Force Field"
+ RUS: "Тяжёлое силовое поле"
 CA_Module_Heavy_Force_Field_Desc:
  Id: 17856
  ENG: "The best force field we can create. It draws a lot of energy and have a very large coverage."
+ RUS: "Лучшее силовое поле из доступных. Потребляет много энергии и имеет очень большую зону покрытия."
 CA_Tech_Force_Fields_III_Name:
  Id: 17857
  ENG: "Force Fields III"
+ RUS: "Силовые поля III"
 CA_Tech_Force_Fields_III_Desc:
  Id: 17858
  ENG: "It is now possible to improve the output of our Force Fields, suited for our big ship hulls."
+ RUS: "Теперь стало возможным повысить мощность наших силовых полей, подходящих для наших крупных корабельных корпусов."
 CA_NanoOrdnanceLocker:
  Id: 17859
  ENG: "Nano Ordnance Locker"
@@ -5987,15 +6047,19 @@ CA_AnAdvancedShieldUsedBy:
 CA_Module_Small_Craft_Deflector_Name:
  Id: 17884
  ENG: "Small Craft Deflector"
+ RUS: "Дефлектор малого корабля"
 CA_Module_Small_Craft_Deflector_Desc:
  Id: 17885
  ENG: "A small sized deflector which can be mounted on small craft."
+ RUS: "Малый дефлектор, который можно установить на малые корабли."
 CA_Module_Small_Craft_Deflector_Adv_Name:
  Id: 17886
  ENG: "Advanced Small Craft Deflector"
+ RUS: "Продвинутый дефлектор малого корабля"
 CA_Module_Small_Craft_Deflector_Adv_Desc:
  Id: 17887
  ENG: "This is an improved and somewhat larger version of the Small Craft Deflector."
+ RUS: "Улучшенная и немного более крупная версия дефлектора малого корабля."
 CA_Tech_NanoweaveMetallurgy_Bonus:
  Id: 17888
  ENG: "Provides a 10% hit point bonus to all ship modules."
@@ -6319,6 +6383,7 @@ CA_InPeacefulTimesOurPeople:
 CA_CreditsPerColonist2:
  Id: 17999
  ENG: "+5 credits per turn"
+ RUS: "+5 кредитов за ход"
 CA_Drone:
  Id: 18000
  ENG: "Drone"
@@ -6630,6 +6695,7 @@ CA_AHeavyMachineGunTurret7:
 CA_Module_Medium_Force_Field_Name:
  Id: 18077
  ENG: "Medium Force Field
+ RUS: "«Среднее силовое поле"
 CA_Tech_AMX50Revolver_Name:
  Id: 18078
  ENG: "Anti Capital Missiles III"
@@ -7121,6 +7187,7 @@ CA_APirateOutcastBaseLed:
 CA_InfrastructureCreditsPerTurn:
  Id: 18200
  ENG: "+2 infrastructure, -100 million population"
+ RUS: "+2 к инфраструктуре, -100 миллионов населения"
 CA_TeleportRing:
  Id: 18201
  ENG: "Teleport ring"
@@ -7156,6 +7223,7 @@ CA_Moontalisk:
 CA_ASubterraneanCreatureThatIs:
  Id: 18209
  ENG: "A subterranean creature that is known to be very rare. They find food by detecting vibrations in the ground, and after digesting excrete it as valuable minerals. Sadly, that sometimes includes our transports and structures. Thanks to highly resistant skin to pressure and high temperatures it can dig several kilometers deep into planets surface and be impossible to kill."
+ RUS: "Подземное существо, считавшееся очень редким. Находит пищу по вибрациям в грунте и, переварив, выделяет её в виде ценных минералов. Увы, иногда в число «жертв» попадают наши транспорты и сооружения. Благодаря коже, крайне устойчивой к давлению и высоким температурам, может зарываться на несколько километров в глубину и быть практически неуязвимым."
 CA_FoodPerTurnInfrastructureTo:
  Id: 18210
  ENG: "-1 food per turn, -1 infrastructure, +1 to planet richness."
@@ -7167,6 +7235,7 @@ CA_Kookrenai:
 CA_ALargeRareAquaticCreature:
  Id: 18212
  ENG: "A large, rare aquatic creature living in the deep lakes and oceans. It is capable of sensing the thoughts of sentient organisms, and agressively lunges for its prey when it detects them. This usually means the loss of our transports. It's capable of rapid regeneration, any detached part of its body is able to grow a fully sized Kookenai on its own. It can hibernate under the bottom of dried water reservoirs for centuries, also wistands huge pressures and temperatures. Best to leave it alone"
+ RUS: "Крупное редкое водное существо, обитающее в глубоких озёрах и океанах. Способно улавливать мысли разумных существ и агрессивно бросается на добычу при их обнаружении, что часто приводит к потере наших транспортов. Быстро регенерирует: любая отделённая часть тела может вырасти в полноценного «Кукенаи». Может впадать в спячку под дном пересохших водоёмов на века и выдерживает огромные давления и температуры. Лучше не тревожить."
 CA_FoodPerTurnInfrastructureTo2:
  Id: 18213
  ENG: "-1 food per turn, -1 infrastructure, +0.5 to planet richness."
@@ -7190,6 +7259,7 @@ CA_Anemoid:
 CA_InvasiveXenomorphicSpeciesThatReproduces:
  Id: 18220
  ENG: "Invasive none agressive xenomorphic species that reproduces rapidly, its very resilient and extremely hard to eradicate. Due to its fast metabolism it can eat twice its body mass a day."
+ RUS: "Инвазивный, неагрессивный ксеноморфный вид с быстрым размножением; чрезвычайно живуч и крайне трудно искореним. Из-за быстрого метаболизма способен съедать в день массу пищи, вдвое превышающую собственную."
 CA_EatsFoodPerTurn:
  Id: 18221
  ENG: "Eats -0.4 food per turn."
@@ -7317,135 +7387,179 @@ CA_AnImprovedVersionOfThe2:
 CA_Tech_OrdnancePayloadI_Name:
  Id: 18252
  ENG: "Ordnance Payload I"
+ RUS: "Боезапас I"
 CA_Tech_OrdnancePayloadII_Name:
  Id: 18253
  ENG: "Ordnance Payload II"
+ RUS: "Боезаряд II"
 CA_Tech_OrdnancePayloadIII_Name:
  Id: 18254
  ENG: "Ordnance Payload III"
+ RUS: "Боезаряд III"
 CA_Tech_OrdnancePayloadIV_Name:
  Id: 18255
  ENG: "Ordnance Payload IV"
+ RUS: "Боезаряд IV"
 CA_Tech_OrdnancePayloadV_Name:
  Id: 18256
  ENG: "Ordnance Payload V"
+ RUS: "Боезаряд V"
 CA_Tech_OrdnancePayloadI_Weapon_Damage_Bonus:
  Id: 18257
  ENG: "Kinetic and Torpedo damage +3%"
+ RUS: "Урон кинетического оружия и торпед +3%"
 CA_Tech_OrdnancePayloadMulti_Weapon_ExplosionRadius_Bonus:
  Id: 18258
  ENG: "Missile and Torpedo Explosion radius +3%"
+ RUS: "Радиус взрыва ракет и торпед +3%"
 CA_Tech_OrdnancePayloadI_missile_Bonus:
  Id: 18259
  ENG: "Missile damage +3%"
+ RUS: "Урон от ракет +3%"
 CA_Tech_RemnantAssembly_Name:
  Id: 18260
  ENG: "Remnant Assembly"
+ RUS: "Сборка Предтечей"
 CA_Tech_RemnantAssembly_Desc:
  Id: 18261
  ENG: "By introducing a very complex way of assembling weapons in Remnant specifications we were able to increase out weapon damage potential."
+ RUS: "Внедрив крайне сложный способ сборки вооружения по спецификациям Предтечей, мы смогли повысить потенциал урона нашего оружия."
 CA_Tech_RemnantAssembly_Weapon_Damage_Bonus:
  Id: 18262
  ENG: "All weapon types damages increased by 10%"
+ RUS: "Урон всех типов оружия увеличен на 10%"
 CA_Tech_RemnantAssembly_Weapon_ExplosionRadius_Bonus:
  Id: 18263
  ENG: "All weapon explosion radius increased by 10%"
+ RUS: "Радиус взрыва всего оружия увеличен на 10%"
 CA_Tech_RemnantMetallurgy_Name:
  Id: 18264
  ENG: "Remnant Metallurgy"
+ RUS: "Металлургия Предтечей"
 CA_Tech_RemnantMetallurgy_Desc:
  Id: 18265
  ENG: "By mixing Remnant compounds from their wreckages with currently known materials, resulted in increased durability."
+ RUS: "Смешивание соединений Предтечей, добытых из их обломков, с известными нам материалами привело к повышению прочности."
 CA_Tech_RemnantMetallurgy_Bonus:
  Id: 18266
  ENG: "Provides a 30% hit point bonus to all ship modules"
+ RUS: "Дает бонус +30% к очкам прочности всех корабельных модулей"
 CA_Tech_RemnantShielding_Name:
  Id: 18267
  ENG: "Remnant Shielding"
+ RUS: "Щиты Предтечей"
 CA_Tech_RemnantShielding_Desc:
  Id: 18268
  ENG: "By studying energy signatures and particles emitted by recovered Remnant shield generators we were able to replicate and introduce those advancements to our own shield generators"
+ RUS: "Изучив энергетические сигнатуры и частицы, испускаемые восстановленными генераторами щитов Предтечей, мы смогли воспроизвести эти достижения и внедрить их в наши собственные генераторы щитов"
 CA_Tech_RemnantShielding_Bonus:
  Id: 18269
  ENG: "Provides a 30% shield power"
+ RUS: "Дает +30% к мощности щита"
 CA_Tech_SlipStreams_Name:
  Id: 18270
  ENG: "Subspace Tunneling"
+ RUS: "Подпространственное туннелирование"
 CA_Tech_SlipStreams_Desc:
  Id: 18271
  ENG: "Using ancient navigation data, our scientists discovered a way to gain access to subspace tunneling between our subspace projectors"
+ RUS: "Используя древние навигационные данные, наши ученые открыли способ создавать подпространственные туннели между нашими субпространственными проекторами"
 CA_Tech_SlipStreams_Bonus:
  Id: 18272
  ENG: "Ships traveling within your own empire's borders gain 30% bonus to their FTL speeds."
+ RUS: "Корабли, перемещающиеся в пределах границ вашей империи, получают +30% к скорости сверхсветового перемещения."
 CA_Tech_PlasmaWeaponsI_Name:
  Id: 18273
  ENG: "Plasma Weapons I"
+ RUS: "Плазменное оружие I"
 CA_Tech_PlasmaWeaponsI_Desc:
  Id: 18274
  ENG: "We are now able to build plasma cannons by using ionized reactor Plasma with higher pressure. The magnetized pressure system requires, however, more constant power and even extra reactor power to fire."
+ RUS: "Теперь мы можем создавать плазменные пушки, используя ионизированную реакторную плазму повышенного давления. Однако система магнитного удержания давления требует постоянной подачи энергии и дополнительной мощности реактора для ведения огня."
 CA_Mod_ShapeMemoryArmor_Desc:
  Id: 18275
  ENG: "Shapememory armor is installed externally on ships for protection. It can regenrate itself but it consumes power and weighs much more than Plasteel.It has better EMP protection, though."
+ RUS: "Броня с памятью формы устанавливается снаружи корабля. Она способна к самовосстановлению, но потребляет энергию и значительно тяжелее пластстали. Зато лучше защищает от ЭМИ."
 CA_Mod_ShapeMemoryArmorSmall_Name:
  Id: 18276
  ENG: "Shapememory Armor Small"
+ RUS: "Малая броня с памятью формы"
 CA_Mod_ShapeMemoryArmorMed_Name:
  Id: 18277
  ENG: "Shapememory Armor Medium"
+ RUS: "Средняя броня с памятью формы"
 CA_Mod_ShapeMemoryArmorLarge_Name:
  Id: 18278
  ENG: "Shapememory Armor Large"
+ RUS: "Большая броня с памятью формы"
 CA_Tech_Terraforming_Name:
  Id: 18279
  ENG: "Terraforming I"
+ RUS: "Терраформирование I"
 CA_Tech_Terraforming_Desc:
  Id: 18280
  ENG: "Terraforming planets is a slow process but it can produce excellent results. If researched, we would be able to construct Teraformers; Vast machines which can transform even the most deadly Volcano into a nice, harmless hill."
+ RUS: "Терраформирование планет - медленный процесс, но он способен дать превосходные результаты. После исследования мы сможем строить терраформеры - громадные машины, которые могут превратить даже самый смертоносный вулкан в милый безобидный холм."
 CA_Tech_Terraforming2_Name:
  Id: 18281
  ENG: "Terraforming II"
+ RUS: "Терраформирование II"
 CA_Tech_Terraforming2_Desc:
  Id: 18282
  ENG: "Continuing the line of Terraforming research, we will be able to make Terraformers even more effective. Terraformers will be able to transform unhabitable sections of the planet into fully habitable lands, increasing population capacity."
+ RUS: "Продолжая линию исследований терраформирования, мы сделаем терраформеры еще более эффективными. Терраформеры смогут превращать непригодные для жизни участки планеты в полностью обитаемые земли, повышая предел численности населения."
 CA_Tech_Terraforming3_Name:
  Id: 18283
  ENG: "Terraforming III"
+ RUS: "Терраформирование III"
 CA_Tech_Terraforming3_Desc:
  Id: 18284
  ENG: "The most advanced technology avaialble for Terraformers. They will be able to transform any habitable planet to the planet environment type our population prefers. This is a true technological marvel!"
+ RUS: "Самая передовая технология, доступная для терраформеров. Они смогут преобразовать любую обитаемую планету в тип среды, который предпочитает наше население. Это настоящее технологическое чудо!"
 CA_Tech_ReactionDrive_CounterEnemyPlanetInhibitionBonus_Bonus:
  Id: 18285
  ENG: "Normaly, hostile planets negate our own projector effects and inhibit our ships. This tech allows us to decrease the enemy planet's gravity well by 10%, if we have a projector in range."
+ RUS: "Обычно враждебные планеты нивелируют действие наших проекторов и тормозят корабли. Эта технология позволяет снизить гравитационную «яму» планеты противника на 10%, если наш проектор в радиусе действия."
 CA_Tech_SubspatialDynamics_CounterEnemyPlanetInhibitionBonus_Bonus:
  Id: 18286
  ENG: "Reduction of an enemy planet's gravity well by a total of 20%, if we have a projector in range."
+ RUS: "Уменьшение гравитационной скважины вражеской планеты в общей сложности на 20%, если у нас есть проектор в радиусе действия."
 CA_MountainShortDesc:
  Id: 18287
  ENG: "+1 Prod per colonists, -1 billion population, -1 infrastructure, 50K production cache"
+ RUS: "+1 продукции на колониста, -1 млрд населения, -1 к инфраструктуре, кэш 50 000 продукции"
 CA_Tech_FleetRepair_Name:
  Id: 18288
  ENG: "Fleet Repair" 
+ RUS: "Ремонт флота"
 CA_Tech_FleetRepair_Desc:
  Id: 18289
  ENG: "As we increase our fleet in size and numbers, we might want to consider investment in fleel wide repair system, to reduce dependency in colonies for repair."  
+ RUS: "По мере роста размеров и численности нашего флота стоит задуматься о вложениях во флотскую систему ремонта, чтобы снизить зависимость от колоний при починке."
 CA_RailgunTurretV2:
  Id: 18290
  ENG: "Advanced Railgun Turret"
+ RUS: "Улучшенная рельсотронная турель"
 CA_TwoRailgunsMountedOnAV2:
  Id: 18291
  ENG: "An upgrade for the older rail gun turret, with higher damage and range."
+ RUS: "Апгрейд старой рельсотронной турели: больше урон и дальность."
 CA_Tech_Shields_Name:
  Id: 18292
  ENG: "Basic Shielding"
+ RUS: "Базовые щиты"
 CA_Tech_Shields_Desc:
  Id: 18293
  ENG: "Our first step into shielding our ships with energy emmitters"
+ RUS: "Наш первый шаг к защите кораблей энергетическими щитами"
 CA_Tech_Deflectors_III_Name:
  Id: 18294
  ENG: "Deflectors III"
+ RUS: "Дефлекторы III"
 CA_Tech_Deflectors_III_Desc:
  Id: 18295
  ENG: "We can create very large Deflector emitters, suited for our largest hulls."
+ RUS: "Мы можем создавать очень крупные излучатели дефлекторов, подходящие для наших самых больших корпусов."
 CA_Module_Class_III_BattleShield_Name:
  Id: 18296
  ENG: "Class III Battle Shield"
@@ -7453,225 +7567,299 @@ CA_Module_Class_III_BattleShield_Name:
 CA_Module_Class_III_BattleShield_Desc:
  Id: 18297
  ENG: "The best battle shield we can produce. It has decent deflection as well" 
+ RUS: "Лучший боевой щит из доступных. Также обладает неплохим показателем дефлектирования."
 CA_Module_Class_III_Deflector_Name:
  Id: 18298
  ENG: "Class III Deflector"
+ RUS: "Дефлектор класса III"
 CA_Module_Class_III_Deflector_Desc:
  Id: 18299
  ENG: "Am immensely larger deflector with more coverage and better deflection." 
+ RUS: "Значительно более крупный дефлектор с расширенным покрытием и лучшим дефлектированием."
 CA_Tech_Aplifiers_I_Name:
  Id: 18300
  ENG: "Shield Amplifiers I"
+ RUS: "Усилители щитов I"
 CA_Tech_Aplifiers_I_Desc:
  Id: 18301
  ENG: "Shield Amplifier technology was developed to amplify strength of energy shield emitters with combination of greatly reduced power consumption."
+ RUS: "Технология усилителей щитов была разработана для повышения мощности излучателей энергетических щитов в сочетании со значительно сниженным энергопотреблением."
 CA_Tech_Aplifiers_II_Name:
  Id: 18302
  ENG: "Shield Amplifiers II"
+ RUS: "Усилители щитов II"
 CA_Tech_Aplifiers_II_Desc:
  Id: 18303
  ENG: "Considerable advancement in shielding technologies lead into developing bigger and more advanced Amplifier to save energy consumption of the bigger shield emitters." 
+ RUS: "Значительный прогресс в технологиях щитов привел к разработке более крупного и совершенного усилителя для экономии энергопотребления более мощных излучателей щитов."
 CA_Tech_Aplifiers_III_Name:
  Id: 18304
  ENG: "Shield Amplifiers III"
+ RUS: "Усилители щитов III"
 CA_Tech_Aplifiers_III_Desc:
  Id: 18305
  ENG: "The ultimate Shield Aplifiers. They are big, but cost effective."   
+ RUS: "Совершенные усилители щитов. Они большие, но экономичные."
 CA_Module_AplifierMk1_Name:
  Id: 18306
  ENG: "Amplifier Mk1"
+ RUS: "Усилитель Mk1"
 CA_Module_Aplifiers_Desc:
  Id: 18307
  ENG: "Increases the strength of all primary shields. The amplification is divided by the number of main shields installed on the ship." 
+ RUS: "Увеличивает мощность всех основных щитов. Усиление делится между числом главных щитов, установленных на корабле."
 CA_Module_AplifierMk2_Name:
  Id: 18308
  ENG: "Amplifier Mk2"
+ RUS: "Усилитель Mk2"
 CA_Module_AplifierMk3_Name:
  Id: 18309
  ENG: "Amplifier Mk3"
+ RUS: "Усилитель Mk3"
 CA_Tech_WirelessPowerI_Name:
  Id: 18310
  ENG: "Wireless Power I"
+ RUS: "Беспроводная энергия I"
 CA_Tech_WirelessPowerI_Desc:
  Id: 18311
  ENG: "Improvements in Microwave Rectennas can enable wireless power transmission in a limited area on spaceships. This breakthrough will hugely improve ergonomy in ship designing."
+ RUS: "Усовершенствование микроволновых ректенн позволяет осуществлять беспроводную передачу энергии в ограниченной зоне на космических кораблях. Этот прорыв значительно улучшит эргономику при проектировании кораблей."
 CA_Module_MicrowaveTrasmitter_Name:
  Id: 18312
  ENG: "Microwave Transmitter"
+ RUS: "Микроволновый передатчик"
 CA_Module_MicrowaveTrasmitter_Desc:
  Id: 18313
  ENG: "This small device will transmit power across limited area in wireless faction."
+ RUS: "Малое устройство для беспроводной передачи энергии на ограниченную дистанцию."
 CA_Module_MRM1_Desc:
  Id: 18314
  ENG: "Medium Range Missile with a terminal velocity system. It also has a small chance to bypass shields."
+ RUS: "Ракета средней дальности с системой терминальной скорости. Имеет небольшой шанс обхода щитов."
 CA_Tech_BeamPD1_Name:
  Id: 18315
  ENG: "Beam PD"
+ RUS: "Лучевая ТЗ"
 CA_Tech_BeamPD1_Desc:
  Id: 18316
  ENG: "Representatives within The Energy Research branch believe they can now use current beam military knowledge to construct fast-tracking beam Point Defense weapons, useful for intercepting incoming anti-ship enemy missiles."
+ RUS: "Представители отдела энергетических исследований считают, что теперь они могут использовать имеющиеся военные знания о лучевом оружии для создания быстро наводящихся лучевых орудий точечной защиты, полезных для перехвата вражеских противокорабельных ракет."
 CA_Tech_BeamPD2_Name:
  Id: 18317
  ENG: "Advanced Beam PD"
+ RUS: "Продвинутая лучевая ТЗ"
 CA_Tech_BeamPD2_Desc:
  Id: 18318
  ENG: "We can research a better beam PD system, which will have more coverage and range."
+ RUS: "Мы можем исследовать улучшенную систему лучевой ТЗ, обладающую большей зоной покрытия и дальностью."
 CA_Module_Beam_PD_Suite_Name:
  Id: 18319
  ENG: "Beam Point Defense Suite"
+ RUS: "Комплекс лучевой ПВО"
 CA_Module_Beam_PD_Suite_Desc:
  Id: 18320
  ENG: "Beam point defense suite can intercept incomming missiles using short pulse beams. It has 360 degree coverage and good range." 
+ RUS: "Комплекс лучевой ПВО перехватывает подлетающие ракеты короткими импульсными лучами. Имеет покрытие 360° и хорошую дальность."
 CA_Module_PulseBeam_Name:
  Id: 18321
  ENG: "Pulse Beam"
+ RUS: "Импульсный луч"
 CA_Module_PulseBeam_Desc:
  Id: 18322
  ENG: "Pulse beams fire accurate beams at fast rate. They are perfect for small craft since their range is limited."
+ RUS: "Импульсные излучатели ведут точный скорострельный огонь; идеальны для малых кораблей из-за ограниченной дальности."
 CA_Module_PulseBeam_Advanced_Name:
  Id: 18323
  ENG: "Advanced Pulse Beam"
+ RUS: "Продвинутый импульсный луч"
 CA_Module_PulseBeam_Advanced_Desc:
  Id: 18324
  ENG: "This is a very high fire rate of the previous Pulse Beam. It has almost twice the firepower and slightly improved range." 
+ RUS: "Существенно более высокая скорострельность по сравнению с прежним импульсным лучом, почти вдвое больше огневой мощи и слегка увеличенная дальность."
 CA_Module_LargeFuelCells_Name:
  Id: 18325
  ENG: "Large Power Cell"
+ RUS: "Большая энерго-ячейка"
 CA_Module_LargeFuelCells_Desc:
  Id: 18326
  ENG: "Large Power cells are much better than smaller Power Cells at storing energy for energy weapon use."
+ RUS: "Большие энергоячейки значительно лучше малых накапливают энергию для питания энергетического оружия."
 CA_Module_LargeFuelCells_Adv_Name:
  Id: 18327
  ENG: "Advanced Large Power Cell"
+ RUS: "Большая продвинутая энерго-ячейка"
 CA_Module_LargeFuelCells_Adv_Desc:
  Id: 18328
  ENG: "Advanced Large Power cells are much better than smaller Advanced Power Cells at storing energy for energy weapon use." 
+ RUS: "Продвинутые большие энергоячейки вмещают больше энергии, чем продвинутые средние, для нужд энергетического оружия."
 CA_Module_RepairBay_Name:
  Id: 18329
  ENG: "Large Repair Bay"
+ RUS: "Большой ремонтный отсек"
 CA_Tech_PowerMgmt1_Name:
  Id: 18330
  ENG: "Power Mgmt I"
+ RUS: "Управление энергией I"
 CA_Tech_PowerMgmt1_Desc:
  Id: 18331
  ENG: "Improvements in power management technology can lead to smaller and larger types of power cells." 
+ RUS: "Усовершенствование технологии управления энергией позволяет создавать меньшие и большие типы энерго-ячеек."
 CA_Tech_PowerMgmt2_Name:
  Id: 18332
  ENG: "Power Mgmt II"
+ RUS: "Управление энергией II"
 CA_Tech_PowerMgmt2_Desc:
  Id: 18333
  ENG: "Improvements in power management technology can lead to a larger type of advanced power cells."  
+ RUS: "Усовершенствование технологии управления энергией позволяет создать больший тип продвинутых энерго-ячеек."
 CA_Module_Needler_Name:
  Id: 18334
  ENG: "Needler"
+ RUS: "Игольник"
 CA_Module_Needler_Desc:
  Id: 18335
  ENG: "The Needler is a Small Craft Cannon which utilizes advancement in magnetic acceleration in order to fire even deadlier projectiles than the Hyper Velocity Vulcan Cannon."
+ RUS: "«Игольник» — орудие малого корабля, использующее магнитный разгон для стрельбы ещё более смертоносными снарядами, чем гиперскоростной «Вулкан»."
 CA_Module_NeedlerAP_Name:
  Id: 18336
  ENG: "Needler AP"
+ RUS: "Игольник AP"
 CA_Module_NeedlerAP_Desc:
  Id: 18337
  ENG: "The Needler AP uses special Armor Piercing projectiles and is a better version of the Basic Needler."
+ RUS: "Версия «Игольника» с особыми бронебойными боеприпасами; лучше базового варианта."
 CA_Module_NeedlerHEAP_Name:
  Id: 18338
  ENG: "Needler HEAP"
+ RUS: "Игольник HEAP"
 CA_Module_NeedlerHEAP_Desc:
  Id: 18339
  ENG: "This ultimate Small Craft weapon incorporates a High Explosive payload along with Armor Piercing Projectile with the Magnetic Acceleration infrastructure."
+ RUS: "Наивысшая версия оружия малого корабля: сочетает фугасную боеголовку и бронебойный снаряд с магнитным разгоном."
 CA_Tech_MassDrivers_Name:
  Id: 18340
  ENG: "Mass Drivers" 
+ RUS: "ЭМ-катапульты"
 CA_Tech_MassDrivers_Desc:
  Id: 18341
  ENG: "Utilization of the low yield magnetic acceleration can lead to creation of bigger cannons with more range and payload to combat heavier ships."
+ RUS: "Использование магнитного ускорения малой мощности позволяет создавать более крупные орудия с большей дальностью и боезапасом для борьбы с тяжелыми кораблями."
 CA_Module_MRTrasmitter_Name:
  Id: 18342
  ENG: "Magnetic Resonance Transmitter"
+ RUS: "Передатчик магнитного резонанса"
 CA_Module_MRTrasmitter_Desc:
  Id: 18343
  ENG: "Increased power transmission area but higher costs and power draw." 
+ RUS: "Увеличивает радиус передачи энергии, но дороже и потребляет больше мощности."
 CA_Module_BosonTrasmitter3_Name:
  Id: 18344
  ENG: "Boson Transmitter" 
+ RUS: "Бозонный передатчик"
 CA_Tech_WirelessPowerII_Name:
  Id: 18345
  ENG: "Wireless Power II"
+ RUS: "Беспроводная энергия II"
 CA_Tech_WirelessPowerII_Desc:
  Id: 18346
  ENG: "Developments in Magnetic Resonance methods can lead to a new type of ship Wireless Transmitter." 
+ RUS: "Развитие методов магнитного резонанса позволяет создать новый тип корабельного беспроводного передатчика."
 CA_Tech_WirelessPowerIII_Name:
  Id: 18347
  ENG: "Wireless Power III"
+ RUS: "Беспроводная энергия III"
 CA_Tech_WirelessPowerIII_Desc:
  Id: 18348
  ENG: "While studying Bosons particles our scientists discovered that they can wirelessly transmit power on limited area. This breakthrough will hugely improve ergonomy in ship designing."  
+ RUS: "Изучая частицы-бозоны, наши ученые обнаружили, что они могут беспроводным образом передавать энергию в ограниченной зоне. Этот прорыв значительно улучшит эргономику при проектировании кораблей."
 CA_Tech_Velocity_Name:
  Id: 18349
  ENG: "Velocity Development"
+ RUS: "Развитие скорости"
 CA_Tech_Velocity_Desc:
  Id: 18350
  ENG: "Invest in Sublight Engine technology."   
+ RUS: "Инвестировать в технологию субсветовых двигателей."
 CA_Bonus_Velocity_Desc:
  Id: 18351
  ENG: "Increase Sublight engine performance by 4%"    
+ RUS: "Повышает характеристики субсветовых двигателей на 4%"
 CA_Tech_MaterialDev_Name:
  Id: 18352
  ENG: "Material Development"
+ RUS: "Развитие материалов"
 CA_Tech_MaterialDev_Desc:
  Id: 18353
  ENG: "Invest in Advanced Material technology."   
+ RUS: "Инвестировать в технологию композитных материалов."
 CA_Bonus_MaterialDev_Desc:
  Id: 18354
  ENG: "Reduce the mass of each ship module by further 2%" 
+ RUS: "Снижает массу каждого корабельного модуля еще на 2%"
 CA_Tech_ShieldDev_Name:
  Id: 18355
  ENG: "Shield Development"
+ RUS: "Развитие щитов"
 CA_Tech_Shield_Desc:
  Id: 18356
  ENG: "Invest in Shield Emmission technology."    
+ RUS: "Инвестировать в технологию излучения щитов."
 CA_Tech_NanoweaveDev_Name:
  Id: 18357
  ENG: "Nanoweave Development"
+ RUS: "Развитие нановолокна"
 CA_Tech_Nanoweave_Desc:
  Id: 18358
  ENG: "Invest in Nanoweave technology."     
+ RUS: "Инвестировать в технологию нановолокна."
 CA_Tech_ComponentsDev_Name:
  Id: 18359
  ENG: "Components Development"
+ RUS: "Развитие компонентов"
 CA_Tech_ComponentsDev_Desc:
  Id: 18360
  ENG: "Invest in Reinforced Components technology."   
+ RUS: "Инвестировать в технологию усиленных компонентов."
 CA_Bonus_ComponentsDev_Desc:
  Id: 18361
  ENG: "Reduce the the effective Explosion Radius of enemy projectiles and missiles by 3%"  
+ RUS: "Снижает эффективный радиус взрыва вражеских снарядов и ракет на 3%"
 CA_Tech_ExplosivesDev_Name:
  Id: 18362
  ENG: "Explosives Development"
+ RUS: "Развитие взрывчатых веществ"
 CA_Tech_ExplosivesDev_Desc:
  Id: 18363
  ENG: "Invest in Explosives technology."   
+ RUS: "Инвестировать в технологию взрывчатых веществ."
 CA_Bonus_ExplosivesDev_Desc:
  Id: 18364
  ENG: "Increase the explosion radius of Missiles and Torpedos by 2%"   
+ RUS: "Увеличивает радиус взрыва ракет и торпед на 2%"
 CA_Tech_PowerCellDev_Name:
  Id: 18365
  ENG: "Power Cells Development"
+ RUS: "Развитие энерго-ячеек"
 CA_Tech_PowerCellDev_Desc:
  Id: 18366
  ENG: "Invest in Power Cells Storage technology."   
+ RUS: "Инвестировать в технологию хранения энергии в энерго-ячейках."
 CA_Bonus_PowerCellDev_Desc:
  Id: 18367
  ENG: "Increase Power Cells Energy Storage by 5%"
+ RUS: "Повышает запас энергии в энерго-ячейках на 5%"
 CA_Tech_OrdnancePayloadDev_Name:
  Id: 18368
  ENG: "Payload Development"
+ RUS: "Развитие боезапаса"
 CA_Tech_OrdnancePayloadDev_Desc:
  Id: 18369
  ENG: "Invest in Ordnance Payload technology."   
+ RUS: "Инвестировать в технологию боезапаса боеприпасов."
 CA_Bonus_OrdnancePayloadDev_Desc:
  Id: 18370
  ENG: "Kinetics and Torpedo damage +2%" 
+ RUS: "Урон кинетического оружия и торпед +2%"
 CA_Tech_SmallStations_Name:
  Id: 18371
  ENG: "Small Stations"
@@ -7679,96 +7867,127 @@ CA_Tech_SmallStations_Name:
 CA_Building_Mine_Name:
  Id: 20001
  ENG: "Small Mine"
+ RUS: "Малая шахта"
 CA_Building_Mine_Desc:
  Id: 20002
  ENG: "This small Mine can contribue a bit for production efforts."
+ RUS: "Эта небольшая шахта может немного помочь производству."
 CA_CrystalPlantName:
  Id: 20003
  ENG: "Crystal Growing Plant"
+ RUS: "Завод по выращиванию кристаллов"
 CA_CrystalPlantDesc:
  Id: 20004
  ENG: "This marvelous building is able to grow a very valuable crystals that can be sold at very high profit." 
+ RUS: "Поразительное сооружение, способное выращивать очень ценные кристаллы для продажи с высокой прибылью."
 CA_NanoContainerDeckName:
  Id: 20005
  ENG: "Nano Container Deck"
+ RUS: "Нано-контейнерная палуба"
 CA_NanoContainerDeckDesc:
  Id: 20006
  ENG: "This Container Deck is using latest Nano Technology breakthrough. It was designed mainly for Stations needing lots of storage area."
+ RUS: "Контейнерная палуба с использованием последних достижений нанотехнологий. Предназначена прежде всего для станций с большими потребностями в хранении."
 CA_Tech_Maintenance_Bonus:
  Id: 20007
  ENG: "Lowers Ship Maintenance by 5%"
+ RUS: "Снижает содержание корабля на 5%"
 CA_Tech_Maintenance_Name:
  Id: 20008
  ENG: "Ship Upkeep  Efficiency" 
+ RUS: "Эффективность содержания кораблей"
 CA_Tech_Maintenance_Desc:
  Id: 20009
  ENG: "As we research and invent bigger and more complex structures, their Maintenance becomes a bottleneck for fleets. We can improve automation methods and build bots to help in ship maintenance tasks."  
+ RUS: "По мере того как мы исследуем и изобретаем все более крупные и сложные конструкции, их техническое обслуживание становится узким местом для флотов. Мы можем усовершенствовать методы автоматизации и создать ботов для помощи в задачах технического обслуживания кораблей."
 CA_Trait_Steppe_Affinity_Name:
  Id: 20010
  ENG: "Steppe Affinity"   
+ RUS: "Степная привязанность"
 CA_Trait_Steppe_Affinity_Desc:
  Id: 20011
  ENG: "Races with Steppe Affinity are originated from a Steppe world and prefer grassy and flat areas"    
+ RUS: "Расы степного происхождения предпочитают травянистые и ровные ландшафты."
 CA_Trait_Xerophiles_Name:
  Id: 20012
  ENG: "Xerophiles"   
+ RUS: "Ксерофилы"
 CA_Trait_Xerophiles_Desc:
  Id: 20013
  ENG: "Xerophile races are originated from a Desert world and prefer hot and dry climates"     
+ RUS: "Расы пустынного происхождения предпочитают жаркий и сухой климат."
 CA_Trait_Terraphiles_Name:
  Id: 20014
  ENG: "Terraphiles"   
+ RUS: "Террафилы"
 CA_Trait_Terraphiles_Desc:
  Id: 20015
  ENG: "Terraphile races are originated from a Terran world and prefer temperate climate"      
+ RUS: "Расы терранского происхождения предпочитают умеренный климат."
 CA_Trait_Jungle_Dwellers_Name:
  Id: 20016
  ENG: "Jungle Dwellers"   
+ RUS: "Жители джунглей"
 CA_Trait_Jungle_Dwellers_Desc:
  Id: 20017
  ENG: "Jungle Dweller races are originated from a Tropical world and prefer hot and humid climates"
+ RUS: "Расы тропического происхождения предпочитают жаркий и влажный климат."
 CA_Trait_Tundra_Dwellers_Name:
  Id: 20018
  ENG: "Tundra Dwellers"   
+ RUS: "Жители тундры"
 CA_Trait_Tundra_Dwellers_Desc:
  Id: 20019
  ENG: "Tundra Dweller races are originated from a Tundra world and prefer cold and dry climates" 
+ RUS: "Расы тундрового происхождения предпочитают холодный и сухой климат."
 CA_Trait_Cryophiles_Name:
  Id: 20020
  ENG: "Cryophiles"   
+ RUS: "Криофилы"
 CA_Trait_Cryophiles_Desc:
  Id: 20021
  ENG: "Cryophiles races are originated from an Ice world and prefer frozen and dry climates"       
+ RUS: "Расы ледяного происхождения предпочитают морозный и сухой климат."
 CA_Trait_Electrophiles_Name:
  Id: 20022
  ENG: "Electrophiles"   
+ RUS: "Электрофилы"
 CA_Trait_Electrophiles_Desc:
  Id: 20023
  ENG: "Electrophiles use a lot of electricity in their day to day life and prefer cold and dry climates. They dislike water whatsoever."        
+ RUS: "Электрофилам в быту требуется много электричества; предпочитают холодный и сухой климат и не переносят воду."
 CA_Trait_Cyborgs_Name:
  Id: 20024
  ENG: "Cyborgs"   
+ RUS: "Киборги"
 CA_Trait_Cyborgs_Desc:
  Id: 20025
  ENG: "Cyborg races consume 70% less food than organic races but need extra recharge when performing high intensity labor, reducing 25% of their production output."         
+ RUS: "Киборги потребляют на 70% меньше еды, чем органические расы, но нуждаются в дополнительной подзарядке при интенсивном труде, что снижает их производство на 25%."
 CA_Trait_Cynical_Name:
  Id: 20026
  ENG: "Cynical"   
+ RUS: "Циничные"
 CA_Trait_Cynical_Desc:
  Id: 20027
  ENG: "Cynical races are dismissive and skeptical of things they cannot understand. As a  result they gain no benefit from artifacts. "          
+ RUS: "Циничные расы недоверчивы к непонятному и потому не получают пользы от артефактов."
 CA_Trait_Green_Conscience_Name:
  Id: 20028
  ENG: "Green Conscience"   
+ RUS: "Зелёная совесть"
 CA_Trait_Green_Conscience_Desc:
  Id: 20029
  ENG: "Your people value the beauty of nature too much to take full advantage of her riches. +0.2 to Homeworld Fertility, -0.5 to Homeworld Richness"           
+ RUS: "Народ слишком ценит красоту природы, чтобы полностью эксплуатировать её богатства. +0.2 к плодородию родного мира, -0.5 к богатству родного мира."
 CA_Tech_BuilderShipEff_Name:
  Id: 20030
  ENG: "Builder Ships"            
+ RUS: "Строительные корабли"
 CA_Tech_BuilderShipEff_Desc:
  Id: 20031
  ENG: "Increased build rate of Builder Ships is important for research station and Planet Defense Operations"             
+ RUS: "Повышенная скорость постройки строительных кораблей важна для исследовательских станций и операций по планетарной обороне"
 CA_RacialTraitSharp_Name:
  Id: 20033
  ENG: "Sharp"


### PR DESCRIPTION
## Summary
Adds Russian (`RUS`) translations for **219** entries in `GameText.yaml` that previously had no `RUS` line. Russian coverage goes from 1742 → **1961 (100% of entries)**.

- **97** entries reuse community Russian translations from the *Combined Arms* mod (1.51).
- **122** entries are newly translated (no prior `RUS`), with terminology aligned to existing Russian strings.

## Scope & safety
- **Purely additive: `+219 / -0`**, single file.
- Only `RUS` lines were inserted (immediately after each `ENG`). No keys, `Id`s, `ENG`, or other languages were touched.
- Formatting tokens, placeholders, line breaks and spacing preserved.

A separate proofreading PR for *existing* Russian strings can follow.
